### PR TITLE
Alter The Default Filter

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const defaultOpts = {
 	filter: (reaction, user) => true
 }
 
+
 function none() {}
 
 class Paginator {


### PR DESCRIPTION
Add this "!user.bot" small line in the default filter so that people dont face the issue in which bot considers it's own reaction somehow passing the filter so the people who dont know much djs can use this easily and wont face a problem 

just a suggestion :) i didnt edit the code because i wanted the dev to fix it itself